### PR TITLE
Copybooks URI client fixes and improvements

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
@@ -16,50 +16,9 @@ export const getContentMock = jest.fn();
 export const getUSSContentsMock = jest.fn();
 export const allMemberMock = jest.fn().mockReturnValue({
   apiResponse: {
-    items: [
-      {
-        member: "copybook",
-      },
-      { member: "DATASET2" },
-    ],
+    items: [],
   },
 });
-class MemberError extends Error {
-  mDetails: {
-    errorCode: number;
-  };
-
-  constructor(message: string, errorCode: number) {
-    super(message);
-    this.mDetails = {
-      errorCode,
-    };
-  }
-}
-
-export const unauthorizedErrorMock = jest
-  .fn()
-  .mockRejectedValue(
-    new MemberError(
-      "Rest API failure with HTTP(S) status 401\nThis operation requires authentication.\nToken is not valid or expired.",
-      401,
-    ),
-  );
-export const notFoundErrorMock = jest
-  .fn()
-  .mockRejectedValue(
-    new MemberError(
-      "Rest API failure with HTTP(S) status 404\nISRZ002 Data set not cataloged",
-      404,
-    ),
-  );
-export const permissionsErrorMock = jest.fn().mockRejectedValue(
-  new MemberError(
-    `Rest API failure with HTTP(S) status 500
-ISRZ002 Authorization failed - You may not use this protected data set. Open 913 abend.`,
-    500,
-  ),
-);
 
 export const mvsApiMock = (allMembers = allMemberMock) =>
   jest.fn().mockReturnValue({
@@ -69,11 +28,7 @@ export const mvsApiMock = (allMembers = allMemberMock) =>
 
 export const allUSSFilemembers = jest.fn().mockReturnValue({
   apiResponse: {
-    items: [
-      { name: "uss_copybook", mode: "-rwxr-xr-x" },
-      { name: "uss_withExt.cpy", mode: "-rwxr-xr-x" },
-      { name: "USS_DATASET2", mode: "-rwxr-xr-x" },
-    ],
+    items: [],
   },
 });
 

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/getZoweExplorerMock.utility.ts
@@ -97,4 +97,5 @@ export const createZoweExplorerMock = (
   getMvsApi: mvsApiMock(allMembers),
   getUssApi: ussApiMock(fileList),
   registeredApiTypes: jest.fn().mockReturnValue([]),
+  onProfileUpdated: jest.fn(),
 });

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -22,6 +22,12 @@ import { URI, Utils } from "vscode-uri";
 
 import { readFile } from "fs/promises";
 
+export const readDirectoryResult: {
+  [path: string]:
+    | (string | { name: string; mode?: string } | [string, FileType])[]
+    | Error;
+} = {};
+
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace workspace {
   export const workspaceFolders = [
@@ -59,7 +65,33 @@ export namespace workspace {
     },
     writeFile: jest.fn(),
     delete: jest.fn().mockReturnValue(true),
-    readDirectory: jest.fn().mockResolvedValue([["fileName", 2]]),
+    readDirectory: jest.fn().mockImplementation((uri: UriType) => {
+      const resultKey = Object.keys(readDirectoryResult).find((key: string) =>
+        uri.path.endsWith(key),
+      );
+      if (!resultKey) {
+        return Promise.resolve([]);
+      }
+      const result = readDirectoryResult[resultKey];
+      if (result instanceof Error) {
+        throw result;
+      } else {
+        return Promise.resolve(
+          result.map((file) => {
+            if (typeof file === "string") {
+              return [`${file}.cpy`, FileType.File];
+            } else if (Array.isArray(file)) {
+              return file;
+            } else if (typeof file === "object") {
+              return [
+                file.name,
+                file.mode?.startsWith("d") ? FileType.Directory : FileType.File,
+              ];
+            }
+          }),
+        );
+      }
+    }),
     createDirectory: jest.fn(),
     stat: jest.fn(),
   };
@@ -272,4 +304,11 @@ export enum DiagnosticSeverity {
   Warning = 1,
   Information = 2,
   Hint = 3,
+}
+
+export enum FileType {
+  Unknown = 0,
+  File = 1,
+  Directory = 2,
+  SymbolicLink = 64,
 }

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -66,8 +66,8 @@ export namespace workspace {
     writeFile: jest.fn(),
     delete: jest.fn().mockReturnValue(true),
     readDirectory: jest.fn().mockImplementation((uri: UriType) => {
-      const resultKey = Object.keys(readDirectoryResult).find((key: string) =>
-        uri.path.endsWith(key),
+      const resultKey = Object.keys(readDirectoryResult).find(
+        (key: string) => uri.path === key,
       );
       if (!resultKey) {
         return Promise.resolve([]);

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/ClearCopybookCacheCommand.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/ClearCopybookCacheCommand.spec.ts
@@ -12,6 +12,7 @@
  *   Broadcom, Inc. - initial API and implementation
  */
 
+import { readDirectoryResult } from "../../__mocks__/vscode";
 import { clearCache } from "../../commands/ClearCopybookCacheCommand";
 import * as vscode from "vscode";
 
@@ -25,6 +26,7 @@ afterAll(() => {
 
 describe("Tests downloaded copybook cache clear", () => {
   it("verify that the clearCache tries to delete cache directories", async () => {
+    readDirectoryResult["/storagePath/e4e/copybooks"] = [{ name: "fileName" }];
     await clearCache(vscode.Uri.file("/storagePath"));
     expect(vscode.workspace.fs.readDirectory).toHaveBeenNthCalledWith(
       1,
@@ -40,11 +42,8 @@ describe("Tests downloaded copybook cache clear", () => {
 
   describe("Cache clear errors", () => {
     beforeAll(() => {
-      jest
-        .spyOn(vscode.workspace.fs, "readDirectory")
-        .mockImplementation(() => {
-          throw vscode.FileSystemError.FileNotFound();
-        });
+      readDirectoryResult["/storagePath/e4e/copybooks"] =
+        vscode.FileSystemError.FileNotFound();
     });
 
     it("doesn't fail if cache folder doesn't exist", async () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/LocalFilesystemResourceService.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/LocalFilesystemResourceService.spec.ts
@@ -175,7 +175,8 @@ describe("LocalFilesystemResourceService test", () => {
 
       expect(findFilesSpy).toHaveBeenCalledWith({
         baseUri: testUri,
-        pattern: "{COPYBOOK.CPY,COPYBOOK.cpy,COPYBOOK.CPB,COPYBOOK.cpb}",
+        pattern:
+          "{[cC][oO][pP][yY][bB][oO][oO][kK].CPY,[cC][oO][pP][yY][bB][oO][oO][kK].cpy,[cC][oO][pP][yY][bB][oO][oO][kK].CPB,[cC][oO][pP][yY][bB][oO][oO][kK].cpb}",
       });
     });
 
@@ -191,7 +192,8 @@ describe("LocalFilesystemResourceService test", () => {
 
       expect(findFilesSpy).toHaveBeenCalledWith({
         baseUri: testUri,
-        pattern: "{COPYBOOK.CPY,COPYBOOK.cpy,COPYBOOK.CPB,COPYBOOK.cpb}",
+        pattern:
+          "{[cC][oO][pP][yY][bB][oO][oO][kK].CPY,[cC][oO][pP][yY][bB][oO][oO][kK].cpy,[cC][oO][pP][yY][bB][oO][oO][kK].CPB,[cC][oO][pP][yY][bB][oO][oO][kK].cpb}",
       });
     });
 
@@ -207,7 +209,8 @@ describe("LocalFilesystemResourceService test", () => {
 
       expect(findFilesSpy).toHaveBeenCalledWith({
         baseUri: testUri,
-        pattern: "{COPYBOOK.CPY,COPYBOOK.cpy,COPYBOOK}",
+        pattern:
+          "{[cC][oO][pP][yY][bB][oO][oO][kK].CPY,[cC][oO][pP][yY][bB][oO][oO][kK].cpy,[cC][oO][pP][yY][bB][oO][oO][kK]}",
       });
     });
 
@@ -223,7 +226,7 @@ describe("LocalFilesystemResourceService test", () => {
 
       expect(findFilesSpy).toHaveBeenCalledWith({
         baseUri: testUri,
-        pattern: "COPYBOOK",
+        pattern: "[cC][oO][pP][yY][bB][oO][oO][kK]",
       });
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -78,7 +78,7 @@ describe("Tests copybook download service", () => {
   beforeEach(() => {
     downloadService = new CopybookDownloadService(
       vscode.Uri.file("/storage-path"),
-      {} as unknown as IApiRegisterClient,
+      createZoweExplorerMock(),
     );
     downloadService["processDownloadError"] = jest.fn();
 
@@ -593,6 +593,7 @@ describe("Tests copybook download service", () => {
             loadNamedProfile: () => ({ name: "profile" }),
           }),
         }),
+        onProfileUpdated: jest.fn(),
       } as unknown as IApiRegisterClient;
 
       jest.spyOn(SettingsService, "getProfileName").mockReturnValue("profile");
@@ -895,6 +896,7 @@ describe("Tests copybook download service", () => {
             loadNamedProfile: () => ({ name: "profile" }),
           }),
         }),
+        onProfileUpdated: jest.fn(),
       } as unknown as IApiRegisterClient;
 
       jest.spyOn(SettingsService, "getProfileName").mockReturnValue("profile");

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -886,7 +886,7 @@ describe("Tests copybook download service", () => {
 
           expect(findFilesSpy).toHaveBeenCalledWith({
             baseUri: vscode.Uri.file("/workspace/copybooks"),
-            pattern: "{COPYBOOK.CPY}",
+            pattern: "{[cC][oO][pP][yY][bB][oO][oO][kK].CPY}",
           });
         });
       });
@@ -921,7 +921,7 @@ describe("Tests copybook download service", () => {
           expect(findFilesSpy).toHaveBeenCalledTimes(1);
           expect(findFilesSpy).toHaveBeenCalledWith({
             baseUri: vscode.Uri.file("/dialect/copybooks"),
-            pattern: "{COPYBOOK.CPY}",
+            pattern: "{[cC][oO][pP][yY][bB][oO][oO][kK].CPY}",
           });
         });
       });
@@ -1442,7 +1442,7 @@ describe("Tests copybook download service", () => {
 
           expect(findFilesSpy).toHaveBeenCalledWith({
             baseUri: vscode.Uri.file("/workspace/local/pg/copybooks"),
-            pattern: "{COPYBOOK.cpy}",
+            pattern: "{[cC][oO][pP][yY][bB][oO][oO][kK].cpy}",
           });
 
           expect(result).toEqual(
@@ -1677,11 +1677,11 @@ describe("Tests copybook download service", () => {
           );
           expect(findFilesSpy).toHaveBeenCalledWith({
             baseUri: vscode.Uri.file("/workspace/local/pg/copybooks"),
-            pattern: "{COPYBOOK.cpy}",
+            pattern: "{[cC][oO][pP][yY][bB][oO][oO][kK].cpy}",
           });
           expect(findFilesSpy).not.toHaveBeenCalledWith({
             baseUri: vscode.Uri.file("/workspace/copybooks"),
-            pattern: "{COPYBOOK.cpy}",
+            pattern: "{[cC][oO][pP][yY][bB][oO][oO][kK].cpy}",
           });
         });
 
@@ -1700,7 +1700,7 @@ describe("Tests copybook download service", () => {
               path: "/workspace/copybooks",
               scheme: "file",
             }) as vscode.Uri,
-            pattern: "{COPYBOOK.cpy}",
+            pattern: "{[cC][oO][pP][yY][bB][oO][oO][kK].cpy}",
           });
         });
       });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -26,17 +26,12 @@ import { CopybookDownloadService } from "../../../services/copybook/CopybookDown
 import { ProfileUtils } from "../../../services/util/ProfileUtils";
 import { Utils } from "../../../services/util/Utils";
 import * as vscode from "vscode";
-import {
-  notFoundErrorMock,
-  permissionsErrorMock,
-  unauthorizedErrorMock,
-  createZoweExplorerMock,
-} from "../../../__mocks__/getZoweExplorerMock.utility";
+import { createZoweExplorerMock } from "../../../__mocks__/getZoweExplorerMock.utility";
 import { DownloadUtil } from "../../../services/copybook/downloader/DownloadUtil";
 import { E4E } from "../../../type/e4eApi";
 import * as ProcessorGroups from "../../../services/ProcessorGroups";
 import { SettingsService } from "../../../services/Settings";
-import { FileNotFound } from "../../../__mocks__/vscode";
+import { FileNotFound, readDirectoryResult } from "../../../__mocks__/vscode";
 import * as ProcessorGroupLoader from "../../../services/ProcessorGroupsLoader";
 import {
   e4eMock,
@@ -60,19 +55,9 @@ describe("Tests copybook download service", () => {
   let profileName: string;
 
   let zoweExplorerMock: IApiRegisterClient;
-  let zoweMockUnauthorizedError: IApiRegisterClient;
-  let zoweMockNotFoundError: IApiRegisterClient;
 
   beforeAll(() => {
     zoweExplorerMock = createZoweExplorerMock();
-    zoweMockUnauthorizedError = createZoweExplorerMock(
-      unauthorizedErrorMock,
-      unauthorizedErrorMock,
-    );
-    zoweMockNotFoundError = createZoweExplorerMock(
-      notFoundErrorMock,
-      notFoundErrorMock,
-    );
   });
 
   beforeEach(() => {
@@ -324,12 +309,20 @@ describe("Tests copybook download service", () => {
       });
 
       describe("invalid credentials", () => {
+        let statSpy: jest.SpyInstance;
         beforeEach(() => {
           downloadService = new CopybookDownloadService(
             vscode.Uri.file("/storage-path"),
-            zoweMockUnauthorizedError,
+            zoweExplorerMock,
           );
           downloadService["processDownloadError"] = jest.fn();
+          statSpy = jest
+            .spyOn(vscode.workspace.fs, "stat")
+            .mockRejectedValue(
+              new Error(
+                "Rest API failure with HTTP(S) status 401\nThis operation requires authentication.",
+              ),
+            );
         });
 
         describe("uss configuration", () => {
@@ -345,15 +338,9 @@ describe("Tests copybook download service", () => {
               DEFAULT_DIALECT,
             );
 
-            expect(unauthorizedErrorMock).toHaveBeenCalledWith(
-              "/u/test/copybooks",
-            );
-            expect(zoweMockUnauthorizedError.getUssApi).toHaveBeenCalled();
-            expect(zoweMockUnauthorizedError.getMvsApi).not.toHaveBeenCalled();
+            expect(statSpy).toHaveBeenCalled();
 
-            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-              "Incorrect credentials in Zowe profile profile.",
-            );
+            expect(vscode.workspace.fs.readDirectory).not.toHaveBeenCalled();
           });
         });
 
@@ -370,25 +357,21 @@ describe("Tests copybook download service", () => {
               DEFAULT_DIALECT,
             );
 
-            expect(unauthorizedErrorMock).toHaveBeenCalledWith(
-              "TEST.COBOL.COPYBOOK",
-            );
-            expect(zoweMockUnauthorizedError.getUssApi).not.toHaveBeenCalled();
-            expect(zoweMockUnauthorizedError.getMvsApi).toHaveBeenCalled();
+            expect(statSpy).toHaveBeenCalled();
 
-            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-              "Incorrect credentials in Zowe profile profile.",
-            );
+            expect(vscode.workspace.fs.readDirectory).not.toHaveBeenCalled();
           });
         });
       });
 
       describe("credentials are valid but copybook dataset doesn't exists", () => {
         let prerequisiteCheckSpy: jest.SpyInstance;
+        let statSpy: jest.SpyInstance;
+
         beforeEach(() => {
           downloadService = new CopybookDownloadService(
             vscode.Uri.file("/storage-path"),
-            zoweMockNotFoundError,
+            zoweExplorerMock,
           );
           workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
           workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
@@ -400,6 +383,13 @@ describe("Tests copybook download service", () => {
             "isPrerequisiteForDownloadSatisfied",
           );
           downloadService.clearCache();
+          statSpy = jest
+            .spyOn(vscode.workspace.fs, "stat")
+            .mockRejectedValue(
+              new Error(
+                "Rest API failure with HTTP(S) status 404 ISRZ002 Data set not cataloged",
+              ),
+            );
         });
 
         it("credentials are considered valid, copybooks can be downloaded", async () => {
@@ -410,6 +400,7 @@ describe("Tests copybook download service", () => {
           );
 
           expect(prerequisiteCheckSpy).toHaveBeenCalled();
+          expect(statSpy).toHaveBeenCalled();
           expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
           expect(result).toBeUndefined();
         });
@@ -420,7 +411,7 @@ describe("Tests copybook download service", () => {
         beforeEach(() => {
           downloadService = new CopybookDownloadService(
             vscode.Uri.file("/storage-path"),
-            createZoweExplorerMock(permissionsErrorMock),
+            zoweExplorerMock,
           );
           workspaceConfigurationMock[PATHS_DSN] = ["TEST.COBOL.COPYBOOK"];
           workspaceConfigurationMock[PATHS_USS] = ["/u/test/copybooks"];
@@ -560,33 +551,14 @@ describe("Tests copybook download service", () => {
   });
   describe("listRemoteCopybooks", () => {
     let zoweExplorerApiMock: IApiRegisterClient;
-    let getAllMembersMock: jest.SpyInstance<IZosFilesResponseMemberList>;
-    let fileListMock: jest.SpyInstance<IZosFilesResponseFileList>;
     let datasetMembers: string[] = [];
     let ussFiles: { name: string; mode?: string }[] = [];
 
-    beforeEach(() => {
-      getAllMembersMock = jest.fn().mockResolvedValue({
-        apiResponse: {
-          items: datasetMembers.map((member) => ({ member: member })),
-        },
-      });
-      fileListMock = jest.fn().mockResolvedValue({
-        apiResponse: {
-          items: ussFiles.map((member) => ({
-            name: member.name,
-            mode: member.mode ?? "-",
-          })),
-        },
-      });
+    const notFoundErrorMessage =
+      "Rest API failure with HTTP(S) status 404 ISRZ002 Data set not cataloged - 'DATASET.WITH.COPYBOOK' was not found in catalog.";
 
+    beforeEach(() => {
       zoweExplorerApiMock = {
-        getMvsApi: () => ({
-          allMembers: getAllMembersMock,
-        }),
-        getUssApi: () => ({
-          fileList: fileListMock,
-        }),
         getExplorerExtenderApi: () => ({
           getProfile: () => "profile",
           getProfilesCache: () => ({
@@ -597,6 +569,15 @@ describe("Tests copybook download service", () => {
       } as unknown as IApiRegisterClient;
 
       jest.spyOn(SettingsService, "getProfileName").mockReturnValue("profile");
+      jest
+        .spyOn(vscode.workspace.fs, "stat")
+        .mockResolvedValue({} as vscode.FileStat);
+
+      readDirectoryResult["NOT.FOUND.DATASET"] = new Error(
+        notFoundErrorMessage,
+      );
+      readDirectoryResult["DATASET.WITH.COPYBOOK"] = datasetMembers;
+      readDirectoryResult["/user/a/copybooks"] = ussFiles;
     });
 
     afterEach(() => {
@@ -636,8 +617,6 @@ describe("Tests copybook download service", () => {
       beforeAll(() => {
         datasetMembers = [];
         ussFiles = [
-          { name: ".", mode: "drwxr-xr-x" },
-          { name: "..", mode: "drwxr-xr-x" },
           {
             name: "CORRECT.CPY",
             mode: "-rwxr-xr-x",
@@ -653,6 +632,10 @@ describe("Tests copybook download service", () => {
           {
             name: "NOEXT",
             mode: "-rwxr-xr-x",
+          },
+          {
+            name: "directory",
+            mode: "drwxr-xr-x",
           },
         ];
         workspaceConfigurationMock = {
@@ -678,13 +661,10 @@ describe("Tests copybook download service", () => {
     });
 
     describe("Error handling ", () => {
-      const errorMessage =
-        "Rest API failure with HTTP(S) status 404 ISRZ002 Data set not cataloged - 'DATASET.WITH.COPYBOOK' was not found in catalog.";
-
       beforeAll(() => {
         ussFiles = [{ name: "USSA" }, { name: "USSB" }];
         workspaceConfigurationMock = {
-          "paths-dsn": ["DATASET.WITH.COPYBOOK"],
+          "paths-dsn": ["NOT.FOUND.DATASET"],
           "paths-uss": ["/user/a/copybooks"],
           "copybook-extensions": [".CPY", ".cpy", ""],
         };
@@ -693,10 +673,6 @@ describe("Tests copybook download service", () => {
       describe("Error in listing one directory should not affect listing other directories", () => {
         it("return list of all members of the uss, and logs error listing of the dataset", async () => {
           const outputChannelMock = { appendLine: jest.fn() };
-
-          getAllMembersMock = jest
-            .fn()
-            .mockRejectedValue(new Error(errorMessage));
 
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
@@ -716,7 +692,7 @@ describe("Tests copybook download service", () => {
           );
 
           expect(outputChannelMock.appendLine).toHaveBeenCalledWith(
-            expect.stringContaining(errorMessage),
+            expect.stringContaining(notFoundErrorMessage),
           );
         });
       });
@@ -736,14 +712,15 @@ describe("Tests copybook download service", () => {
             cds.clearCache();
           }
 
-          expect(getAllMembersMock).toHaveBeenCalledTimes(10);
+          expect(
+            (vscode.workspace.fs.readDirectory as jest.Mock).mock.calls.filter(
+              (call: [vscode.Uri]) =>
+                call[0].path === "/profile/user/a/copybooks",
+            ).length,
+          ).toEqual(10);
         });
 
         it("Failing requests are blocked after n attempts", async () => {
-          getAllMembersMock = jest
-            .fn()
-            .mockRejectedValue(new Error(errorMessage));
-
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
             zoweExplorerApiMock,
@@ -756,22 +733,21 @@ describe("Tests copybook download service", () => {
             );
           }
 
-          expect(getAllMembersMock).toHaveBeenCalledTimes(
-            FAILED_REQUESTS_LIMIT,
-          );
+          expect(
+            (vscode.workspace.fs.readDirectory as jest.Mock).mock.calls.filter(
+              (call: [vscode.Uri]) =>
+                call[0].path === "/profile/NOT.FOUND.DATASET",
+            ).length,
+          ).toEqual(FAILED_REQUESTS_LIMIT);
 
           expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-            `Request to list dataset members profile/DATASET.WITH.COPYBOOK keeps failing repeatedly. Disabling future requests. ${errorMessage}`,
+            `Request to list dataset members profile/NOT.FOUND.DATASET keeps failing repeatedly. Disabling future requests. ${notFoundErrorMessage}`,
             "Keep disabled",
             "Reenable",
           );
         });
 
         it("Reenable failed Zowe request command unblocks failed requests", async () => {
-          getAllMembersMock = jest
-            .fn()
-            .mockRejectedValue(new Error(errorMessage));
-
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
             zoweExplorerApiMock,
@@ -784,9 +760,12 @@ describe("Tests copybook download service", () => {
             );
           }
 
-          expect(getAllMembersMock).toHaveBeenCalledTimes(
-            FAILED_REQUESTS_LIMIT,
-          );
+          expect(
+            (vscode.workspace.fs.readDirectory as jest.Mock).mock.calls.filter(
+              (call: [vscode.Uri]) =>
+                call[0].path === "/profile/NOT.FOUND.DATASET",
+            ).length,
+          ).toEqual(FAILED_REQUESTS_LIMIT);
 
           cds.reenableFailedRequests();
 
@@ -796,10 +775,12 @@ describe("Tests copybook download service", () => {
               DEFAULT_DIALECT,
             );
           }
-
-          expect(getAllMembersMock).toHaveBeenCalledTimes(
-            FAILED_REQUESTS_LIMIT * 2,
-          );
+          expect(
+            (vscode.workspace.fs.readDirectory as jest.Mock).mock.calls.filter(
+              (call: [vscode.Uri]) =>
+                call[0].path === "/profile/NOT.FOUND.DATASET",
+            ).length,
+          ).toEqual(FAILED_REQUESTS_LIMIT * 2);
         });
       });
     });
@@ -857,47 +838,13 @@ describe("Tests copybook download service", () => {
   });
 
   describe("resolveCopybookURI", () => {
-    let zoweExplorerApiMock: IApiRegisterClient;
-    let allMembersMock: jest.SpyInstance<IZosFilesResponseMemberList>;
-    let fileListMock: jest.SpyInstance<IZosFilesResponseFileList>;
     beforeEach(() => {
-      allMembersMock = jest.fn().mockImplementation((dsn) => {
-        return {
-          apiResponse: {
-            items:
-              dsn === "DATASET.WITH.COPYBOOKS" ? [{ member: "COPYBOOK" }] : [],
-          },
-        };
-      });
-      fileListMock = jest.fn().mockImplementation((uss) => {
-        return {
-          apiResponse: {
-            items:
-              uss === "/remote/uss/copybooks"
-                ? [
-                    { name: "COPYBOOK.CPY", mode: "-" },
-                    { name: "CaSEsEnSiTiVe.CpY", mode: "-" },
-                  ]
-                : [],
-          },
-        };
-      });
-
-      zoweExplorerApiMock = {
-        getMvsApi: () => ({
-          allMembers: allMembersMock,
-        }),
-        getUssApi: () => ({
-          fileList: fileListMock,
-        }),
-        getExplorerExtenderApi: () => ({
-          getProfile: () => "profile",
-          getProfilesCache: () => ({
-            loadNamedProfile: () => ({ name: "profile" }),
-          }),
-        }),
-        onProfileUpdated: jest.fn(),
-      } as unknown as IApiRegisterClient;
+      readDirectoryResult["DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
+      readDirectoryResult["/remote/uss/copybooks"] = [
+        ["COPYBOOK.CPY", vscode.FileType.File],
+        ["CaSEsEnSiTiVe.CpY", vscode.FileType.File],
+        ["directory", vscode.FileType.Directory],
+      ];
 
       jest.spyOn(SettingsService, "getProfileName").mockReturnValue("profile");
       jest.spyOn(vscode.workspace, "getWorkspaceFolder").mockReturnValue({
@@ -927,7 +874,7 @@ describe("Tests copybook download service", () => {
         it("local copybook workspace folder is searched", async () => {
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
-            zoweExplorerApiMock,
+            zoweExplorerMock,
           );
           const result = await cds.resolveCopybookURI(
             vscode.Uri.file("/test.cbl").toString(),
@@ -987,12 +934,15 @@ describe("Tests copybook download service", () => {
           "copybook-extensions": [".CPY"],
         };
         profileName = "profile";
+
+        readDirectoryResult["OTHER.DATASET"] = [];
+        readDirectoryResult["DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
       });
 
       it("zowe ds uri is constructed", async () => {
         const cds = new CopybookDownloadService(
           vscode.Uri.file("/globalStorage"),
-          zoweExplorerApiMock,
+          zoweExplorerMock,
         );
         const result = await cds.resolveCopybookURI(
           vscode.Uri.file("/test.cbl").toString(),
@@ -1001,10 +951,15 @@ describe("Tests copybook download service", () => {
         );
 
         expect(result).toEqual(
-          "zowe-ds:/profile/DATASET.WITH.COPYBOOKS/COPYBOOK",
+          "zowe-ds:/profile/DATASET.WITH.COPYBOOKS/COPYBOOK.cpy",
         );
-        expect(allMembersMock).toHaveBeenCalledWith("OTHER.DATASET");
-        expect(allMembersMock).toHaveBeenCalledWith("DATASET.WITH.COPYBOOKS");
+
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledWith(
+          vscode.Uri.parse("zowe-ds:/profile/OTHER.DATASET"),
+        );
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledWith(
+          vscode.Uri.parse("zowe-ds:/profile/DATASET.WITH.COPYBOOKS"),
+        );
       });
     });
 
@@ -1020,7 +975,7 @@ describe("Tests copybook download service", () => {
       it("zowe ds uri is constructed", async () => {
         const cds = new CopybookDownloadService(
           vscode.Uri.file("/globalStorage"),
-          zoweExplorerApiMock,
+          zoweExplorerMock,
         );
         const result = await cds.resolveCopybookURI(
           vscode.Uri.file("/test.cbl").toString(),
@@ -1032,14 +987,18 @@ describe("Tests copybook download service", () => {
           "zowe-uss:/profile/remote/uss/copybooks/COPYBOOK.CPY",
         );
 
-        expect(fileListMock).toHaveBeenCalledWith("/user/copybooks");
-        expect(fileListMock).toHaveBeenCalledWith("/remote/uss/copybooks");
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledWith(
+          vscode.Uri.parse("zowe-uss:/profile/user/copybooks"),
+        );
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledWith(
+          vscode.Uri.parse("zowe-uss:/profile/remote/uss/copybooks"),
+        );
       });
 
       it("copybook are case insensitive", async () => {
         const cds = new CopybookDownloadService(
           vscode.Uri.file("/globalStorage"),
-          zoweExplorerApiMock,
+          zoweExplorerMock,
         );
         const result = await cds.resolveCopybookURI(
           vscode.Uri.file("/test.cbl").toString(),
@@ -1448,7 +1407,10 @@ describe("Tests copybook download service", () => {
         };
         jest
           .spyOn(ProcessorGroupLoader, "readProcessorGroupsFileContent")
-          .mockResolvedValue(processorGroups);
+          // .mockResolvedValue(processorGroups);
+          .mockImplementation(() => {
+            return Promise.resolve(processorGroups);
+          });
         jest
           .spyOn(ProcessorGroupLoader, "readProgramConfigFileContent")
           .mockResolvedValue(programConfigs);
@@ -1497,21 +1459,14 @@ describe("Tests copybook download service", () => {
           findFilesSpyResult = [];
         });
 
-        beforeEach(() => {
-          allMembersMock = jest.fn().mockImplementation((dsn) => {
-            return {
-              apiResponse: {
-                items:
-                  dsn === "PROCGRP.COPYBOOKS" ? [{ member: "COPYBOOK" }] : [],
-              },
-            };
-          });
+        beforeAll(() => {
+          readDirectoryResult["PROCGRP.COPYBOOKS"] = ["COPYBOOK"];
         });
 
         it("return zowe dsn copybook uri", async () => {
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
-            zoweExplorerApiMock,
+            zoweExplorerMock,
             e4eMock,
           );
           const result = await cds.resolveCopybookURI(
@@ -1521,7 +1476,7 @@ describe("Tests copybook download service", () => {
           );
 
           expect(result).toEqual(
-            "zowe-ds:/pg_profile/PROCGRP.COPYBOOKS/COPYBOOK",
+            "zowe-ds:/pg_profile/PROCGRP.COPYBOOKS/COPYBOOK.cpy",
           );
         });
       });
@@ -1529,31 +1484,17 @@ describe("Tests copybook download service", () => {
       describe("resolve uss processor in group copybooks", () => {
         beforeAll(() => {
           findFilesSpyResult = [];
-        });
 
-        beforeEach(() => {
-          allMembersMock = jest.fn().mockResolvedValue({
-            apiResponse: {
-              items: [],
-            },
-          });
-
-          fileListMock = jest.fn().mockImplementation((uss) => {
-            return {
-              apiResponse: {
-                items:
-                  uss === "/uss/procgrp/copybooks"
-                    ? [{ name: "COPYBOOK.cpy", mode: "-" }]
-                    : [],
-              },
-            };
-          });
+          readDirectoryResult["PROCGRP.COPYBOOKS"] = [];
+          readDirectoryResult["/uss/procgrp/copybooks"] = [
+            { name: "COPYBOOK.cpy", mode: "-" },
+          ];
         });
 
         it("return zowe uss copybook uri", async () => {
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
-            zoweExplorerApiMock,
+            zoweExplorerMock,
             e4eMock,
           );
           const result = await cds.resolveCopybookURI(
@@ -1660,15 +1601,13 @@ describe("Tests copybook download service", () => {
 
       describe("copybooks search respects processor group definitions order", () => {
         beforeEach(() => {
-          allMembersMock = jest.fn().mockResolvedValue({
-            apiResponse: { items: [{ member: "COPYBOOK" }] },
-          });
+          readDirectoryResult["PROCGRP.COPYBOOKS"] = ["COPYBOOK"];
         });
 
         it("datasetFirst group -> resolves to dataset uri", async () => {
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
-            zoweExplorerApiMock,
+            zoweExplorerMock,
             e4eMock,
           );
           const result = await cds.resolveCopybookURI(
@@ -1678,14 +1617,14 @@ describe("Tests copybook download service", () => {
           );
 
           expect(result).toEqual(
-            "zowe-ds:/pg_profile/PROCGRP.COPYBOOKS/COPYBOOK",
+            "zowe-ds:/pg_profile/PROCGRP.COPYBOOKS/COPYBOOK.cpy",
           );
         });
 
         it("endevorFirst group -> resolves to endevor uri", async () => {
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
-            zoweExplorerApiMock,
+            zoweExplorerMock,
             e4eMock,
           );
           const result = await cds.resolveCopybookURI(
@@ -1712,7 +1651,7 @@ describe("Tests copybook download service", () => {
 
           const cds = new CopybookDownloadService(
             vscode.Uri.file("/globalStorage"),
-            zoweExplorerApiMock,
+            zoweExplorerMock,
             e4eMock,
           );
           const result = await cds.resolveCopybookURI(
@@ -1789,7 +1728,7 @@ describe("Tests copybook download service", () => {
       it("return local copybook uri", async () => {
         const cds = new CopybookDownloadService(
           vscode.Uri.file("/globalStorage"),
-          zoweExplorerApiMock,
+          zoweExplorerMock,
         );
         const result = await cds.resolveCopybookURI(
           "file:///test.cbl",
@@ -1810,12 +1749,14 @@ describe("Tests copybook download service", () => {
           "copybook-extensions": [".CPY", ".cpy"],
         };
         profileName = "profile";
+        readDirectoryResult["DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
+        readDirectoryResult["/user/copybooks"] = ["COPYBOOK"];
       });
 
       it("return dsn copybook uri", async () => {
         const cds = new CopybookDownloadService(
           vscode.Uri.file("/globalStorage"),
-          zoweExplorerApiMock,
+          zoweExplorerMock,
         );
         const result = await cds.resolveCopybookURI(
           "file:///test.cbl",
@@ -1824,7 +1765,7 @@ describe("Tests copybook download service", () => {
         );
 
         expect(result).toEqual(
-          "zowe-ds:/profile/DATASET.WITH.COPYBOOKS/COPYBOOK",
+          "zowe-ds:/profile/DATASET.WITH.COPYBOOKS/COPYBOOK.cpy",
         );
       });
     });
@@ -1839,7 +1780,7 @@ describe("Tests copybook download service", () => {
       it("checks the order of resolution is same as the one provided in user settings", async () => {
         const cds = new CopybookDownloadService(
           vscode.Uri.file("/globalStorage"),
-          zoweExplorerApiMock,
+          zoweExplorerMock,
         );
 
         await cds.resolveCopybookURI(
@@ -1848,8 +1789,14 @@ describe("Tests copybook download service", () => {
           DEFAULT_DIALECT,
         );
 
-        expect(allMembersMock).toHaveBeenNthCalledWith(1, "FIRST.DATASET");
-        expect(allMembersMock).toHaveBeenNthCalledWith(2, "SECOND.DATASET");
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenNthCalledWith(
+          1,
+          vscode.Uri.parse("zowe-ds:/profile/FIRST.DATASET"),
+        );
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenNthCalledWith(
+          2,
+          vscode.Uri.parse("zowe-ds:/profile/SECOND.DATASET"),
+        );
       });
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -573,11 +573,11 @@ describe("Tests copybook download service", () => {
         .spyOn(vscode.workspace.fs, "stat")
         .mockResolvedValue({} as vscode.FileStat);
 
-      readDirectoryResult["NOT.FOUND.DATASET"] = new Error(
+      readDirectoryResult["/profile/NOT.FOUND.DATASET"] = new Error(
         notFoundErrorMessage,
       );
-      readDirectoryResult["DATASET.WITH.COPYBOOK"] = datasetMembers;
-      readDirectoryResult["/user/a/copybooks"] = ussFiles;
+      readDirectoryResult["/profile/DATASET.WITH.COPYBOOK"] = datasetMembers;
+      readDirectoryResult["/profile/user/a/copybooks"] = ussFiles;
     });
 
     afterEach(() => {
@@ -839,8 +839,8 @@ describe("Tests copybook download service", () => {
 
   describe("resolveCopybookURI", () => {
     beforeEach(() => {
-      readDirectoryResult["DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
-      readDirectoryResult["/remote/uss/copybooks"] = [
+      readDirectoryResult["/profile/DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
+      readDirectoryResult["/profile/remote/uss/copybooks"] = [
         ["COPYBOOK.CPY", vscode.FileType.File],
         ["CaSEsEnSiTiVe.CpY", vscode.FileType.File],
         ["directory", vscode.FileType.Directory],
@@ -935,8 +935,8 @@ describe("Tests copybook download service", () => {
         };
         profileName = "profile";
 
-        readDirectoryResult["OTHER.DATASET"] = [];
-        readDirectoryResult["DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
+        readDirectoryResult["/profile/OTHER.DATASET"] = [];
+        readDirectoryResult["/profile/DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
       });
 
       it("zowe ds uri is constructed", async () => {
@@ -1407,10 +1407,7 @@ describe("Tests copybook download service", () => {
         };
         jest
           .spyOn(ProcessorGroupLoader, "readProcessorGroupsFileContent")
-          // .mockResolvedValue(processorGroups);
-          .mockImplementation(() => {
-            return Promise.resolve(processorGroups);
-          });
+          .mockResolvedValue(processorGroups);
         jest
           .spyOn(ProcessorGroupLoader, "readProgramConfigFileContent")
           .mockResolvedValue(programConfigs);
@@ -1460,7 +1457,7 @@ describe("Tests copybook download service", () => {
         });
 
         beforeAll(() => {
-          readDirectoryResult["PROCGRP.COPYBOOKS"] = ["COPYBOOK"];
+          readDirectoryResult["/pg_profile/PROCGRP.COPYBOOKS"] = ["COPYBOOK"];
         });
 
         it("return zowe dsn copybook uri", async () => {
@@ -1484,9 +1481,8 @@ describe("Tests copybook download service", () => {
       describe("resolve uss processor in group copybooks", () => {
         beforeAll(() => {
           findFilesSpyResult = [];
-
-          readDirectoryResult["PROCGRP.COPYBOOKS"] = [];
-          readDirectoryResult["/uss/procgrp/copybooks"] = [
+          readDirectoryResult["/pg_profile/PROCGRP.COPYBOOKS"] = [];
+          readDirectoryResult["/pg_profile/uss/procgrp/copybooks"] = [
             { name: "COPYBOOK.cpy", mode: "-" },
           ];
         });
@@ -1601,7 +1597,7 @@ describe("Tests copybook download service", () => {
 
       describe("copybooks search respects processor group definitions order", () => {
         beforeEach(() => {
-          readDirectoryResult["PROCGRP.COPYBOOKS"] = ["COPYBOOK"];
+          readDirectoryResult["/pg_profile/PROCGRP.COPYBOOKS"] = ["COPYBOOK"];
         });
 
         it("datasetFirst group -> resolves to dataset uri", async () => {
@@ -1749,8 +1745,8 @@ describe("Tests copybook download service", () => {
           "copybook-extensions": [".CPY", ".cpy"],
         };
         profileName = "profile";
-        readDirectoryResult["DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
-        readDirectoryResult["/user/copybooks"] = ["COPYBOOK"];
+        readDirectoryResult["/profile/DATASET.WITH.COPYBOOKS"] = ["COPYBOOK"];
+        readDirectoryResult["/profile/user/copybooks"] = ["COPYBOOK"];
       });
 
       it("return dsn copybook uri", async () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/CopybookDownloadServiceTest.spec.ts
@@ -63,7 +63,7 @@ describe("Tests copybook download service", () => {
   beforeEach(() => {
     downloadService = new CopybookDownloadService(
       vscode.Uri.file("/storage-path"),
-      createZoweExplorerMock(),
+      zoweExplorerMock,
     );
     downloadService["processDownloadError"] = jest.fn();
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
@@ -15,14 +15,12 @@
 import { CopybookDownloaderForDsn } from "../../../../services/copybook/downloader/CopybookDownloaderForDsn";
 import { createZoweExplorerMock } from "../../../../__mocks__/getZoweExplorerMock.utility";
 import * as vscode from "vscode";
+import { readDirectoryResult } from "../../../../__mocks__/vscode";
 
 describe("Tests Copybook download from DNS", () => {
-  let readDirectoryMock: jest.SpyInstance;
   beforeEach(() => {
     jest.clearAllMocks();
-    readDirectoryMock = jest
-      .spyOn(vscode.workspace.fs, "readDirectory")
-      .mockResolvedValue([["copybook.cpy", vscode.FileType.File]]);
+    readDirectoryResult["/profile/dataset"] = ["copybook"];
   });
 
   describe("checks the copybook download using ZE DSN API's", () => {
@@ -36,7 +34,7 @@ describe("Tests Copybook download from DNS", () => {
           "dataset",
           "copybook",
         );
-        expect(readDirectoryMock).toHaveBeenCalledTimes(1);
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledTimes(1);
         expect(res).toStrictEqual({ extension: ".cpy", name: "copybook" });
       });
     });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForDsnTest.spec.ts
@@ -13,39 +13,22 @@
  */
 
 import { CopybookDownloaderForDsn } from "../../../../services/copybook/downloader/CopybookDownloaderForDsn";
-import { ProfileUtils } from "../../../../services/util/ProfileUtils";
-import {
-  createZoweExplorerMock,
-  allMemberMock,
-} from "../../../../__mocks__/getZoweExplorerMock.utility";
+import { createZoweExplorerMock } from "../../../../__mocks__/getZoweExplorerMock.utility";
 import * as vscode from "vscode";
-import { TextEncoder } from "util";
-import { SettingsService } from "../../../../services/Settings";
 
 describe("Tests Copybook download from DNS", () => {
+  let readDirectoryMock: jest.SpyInstance;
   beforeEach(() => {
     jest.clearAllMocks();
-    jest
-      .spyOn(vscode.workspace.fs, "readFile")
-      .mockReturnValue(
-        Promise.resolve(new TextEncoder().encode("copybook content")),
-      );
+    readDirectoryMock = jest
+      .spyOn(vscode.workspace.fs, "readDirectory")
+      .mockResolvedValue([["copybook.cpy", vscode.FileType.File]]);
   });
 
   describe("checks the copybook download using ZE DSN API's", () => {
     const downloader = new CopybookDownloaderForDsn(createZoweExplorerMock());
 
     describe("checks eligible copybook invoke appropriate ZE Api's", () => {
-      ProfileUtils.getProfileNameForCopybook = jest
-        .fn()
-        .mockReturnValue("test-profile");
-      SettingsService.getCopybookFileEncoding = jest
-        .fn()
-        .mockReturnValue("utf8");
-      vscode.Uri.joinPath = jest
-        .fn()
-        .mockReturnValue({ fsPath: "profile/dsn.path/copybook" });
-
       it("checks hasMember adds fetched list to cache when cache doesn't have the member and hasMember uses cache when have member is cached", async () => {
         await downloader.hasMember("profile", "dataset", "copybook");
         const res = await downloader.hasMember(
@@ -53,8 +36,8 @@ describe("Tests Copybook download from DNS", () => {
           "dataset",
           "copybook",
         );
-        expect(allMemberMock).toHaveBeenCalledTimes(1);
-        expect(res).toStrictEqual(true);
+        expect(readDirectoryMock).toHaveBeenCalledTimes(1);
+        expect(res).toStrictEqual({ extension: ".cpy", name: "copybook" });
       });
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
@@ -46,7 +46,7 @@ describe("Tests Copybook download from USS", () => {
     });
   });
 
-  describe("checks the copybook download using ZE USS APIs", () => {
+  describe("checks the copybook download using ZE USS API's", () => {
     let downloader: CopybookDownloaderForUss;
     beforeEach(() => {
       jest
@@ -55,7 +55,7 @@ describe("Tests Copybook download from USS", () => {
       downloader = new CopybookDownloaderForUss(createZoweExplorerMock());
     });
 
-    describe("checks eligible copybook invoke appropriate ZE Apis", () => {
+    describe("checks eligible copybook invoke appropriate ZE Api's", () => {
       beforeEach(() => {
         jest
           .spyOn(ProfileUtils, "getProfileNameForCopybook")
@@ -69,7 +69,7 @@ describe("Tests Copybook download from USS", () => {
           .mockResolvedValue([".cpy", ""]);
       });
 
-      it("checks hasMember adds fetched list to cache when cache doesnt have the member and checks hasMember uses cache when have member is cached", async () => {
+      it("checks hasMember adds fetched list to cache when cache doesn't have the member and checks hasMember uses cache when have member is cached", async () => {
         await downloader.hasMember("profile", "/ussFile", "uss_copybook");
         const res = await downloader.hasMember(
           "profile",

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
@@ -18,10 +18,9 @@ import * as vscode from "vscode";
 import { TextEncoder } from "util";
 import { SettingsService } from "../../../../services/Settings";
 import { CopybookDownloaderForUss } from "../../../../services/copybook/downloader/CopybookDownloaderForUss";
+import { readDirectoryResult } from "../../../../__mocks__/vscode";
 
 describe("Tests Copybook download from USS", () => {
-  let readDirectoryMock: jest.SpyInstance;
-
   beforeEach(() => {
     jest.clearAllMocks();
     jest
@@ -29,9 +28,10 @@ describe("Tests Copybook download from USS", () => {
       .mockReturnValue(
         Promise.resolve(new TextEncoder().encode("copybook content")),
       );
-    readDirectoryMock = jest
-      .spyOn(vscode.workspace.fs, "readDirectory")
-      .mockResolvedValue([["uss_copybook.cpy", vscode.FileType.File]]);
+
+    readDirectoryResult["/profile/ussFile"] = [
+      ["uss_copybook.cpy", vscode.FileType.File],
+    ];
   });
 
   describe("checks if the copybook is eligible to dowload passed on user settings", () => {
@@ -46,7 +46,7 @@ describe("Tests Copybook download from USS", () => {
     });
   });
 
-  describe("checks the copybook download using ZE USS API's", () => {
+  describe("checks the copybook download using ZE USS APIs", () => {
     let downloader: CopybookDownloaderForUss;
     beforeEach(() => {
       jest
@@ -55,7 +55,7 @@ describe("Tests Copybook download from USS", () => {
       downloader = new CopybookDownloaderForUss(createZoweExplorerMock());
     });
 
-    describe("checks eligible copybook invoke appropriate ZE Api's", () => {
+    describe("checks eligible copybook invoke appropriate ZE Apis", () => {
       beforeEach(() => {
         jest
           .spyOn(ProfileUtils, "getProfileNameForCopybook")
@@ -67,19 +67,16 @@ describe("Tests Copybook download from USS", () => {
         jest
           .spyOn(SettingsService, "getCopybookExtension")
           .mockResolvedValue([".cpy", ""]);
-        jest.spyOn(vscode.Uri, "joinPath").mockReturnValue({
-          fsPath: "profile/uss/path/copybook",
-        } as unknown as vscode.Uri);
       });
 
-      it("checks hasMember adds fetched list to cache when cache doesn't have the member and checks hasMember uses cache when have member is cached", async () => {
-        await downloader.hasMember("profile", "ussFile", "uss_copybook");
+      it("checks hasMember adds fetched list to cache when cache doesnt have the member and checks hasMember uses cache when have member is cached", async () => {
+        await downloader.hasMember("profile", "/ussFile", "uss_copybook");
         const res = await downloader.hasMember(
           "profile",
-          "ussFile",
+          "/ussFile",
           "uss_copybook",
         );
-        expect(readDirectoryMock).toHaveBeenCalledTimes(1);
+        expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledTimes(1);
         expect(res).toStrictEqual({ extension: ".cpy", name: "uss_copybook" });
       });
     });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/copybook/download/CopybookDownloaderForUssTest.spec.ts
@@ -13,16 +13,15 @@
  */
 
 import { ProfileUtils } from "../../../../services/util/ProfileUtils";
-import {
-  createZoweExplorerMock,
-  allUSSFilemembers,
-} from "../../../../__mocks__/getZoweExplorerMock.utility";
+import { createZoweExplorerMock } from "../../../../__mocks__/getZoweExplorerMock.utility";
 import * as vscode from "vscode";
 import { TextEncoder } from "util";
 import { SettingsService } from "../../../../services/Settings";
 import { CopybookDownloaderForUss } from "../../../../services/copybook/downloader/CopybookDownloaderForUss";
 
 describe("Tests Copybook download from USS", () => {
+  let readDirectoryMock: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest
@@ -30,6 +29,9 @@ describe("Tests Copybook download from USS", () => {
       .mockReturnValue(
         Promise.resolve(new TextEncoder().encode("copybook content")),
       );
+    readDirectoryMock = jest
+      .spyOn(vscode.workspace.fs, "readDirectory")
+      .mockResolvedValue([["uss_copybook.cpy", vscode.FileType.File]]);
   });
 
   describe("checks if the copybook is eligible to dowload passed on user settings", () => {
@@ -77,8 +79,8 @@ describe("Tests Copybook download from USS", () => {
           "ussFile",
           "uss_copybook",
         );
-        expect(allUSSFilemembers).toHaveBeenCalledTimes(1);
-        expect(res).toStrictEqual(true);
+        expect(readDirectoryMock).toHaveBeenCalledTimes(1);
+        expect(res).toStrictEqual({ extension: ".cpy", name: "uss_copybook" });
       });
     });
   });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ProfileUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/ProfileUtilsTest.spec.ts
@@ -57,6 +57,7 @@ function getZoweExplorerMock(): IApiRegisterClient {
       },
     }),
     registeredApiTypes: () => ["zosmf"],
+    onProfileUpdated: jest.fn(),
   };
 }
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/util/SubroutineUtilsTest.spec.ts
@@ -41,7 +41,7 @@ describe("SubroutineUtils", () => {
         const uri = await resolveSubroutineURI("SUB1");
         expect(uri).toEqual("file:///coding/cobol/subroutines/SUB1.cob");
         expect(findFilesSpy).toHaveBeenCalledWith(
-          "subroutines/**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
+          "subroutines/**/[sS][uU][bB][11]{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
           null,
           1,
         );
@@ -95,7 +95,7 @@ describe("SubroutineUtils", () => {
       expect(findFilesSpy).toHaveBeenCalledWith(
         {
           baseUri: "/absolute/subroutines",
-          pattern: "**/SUB1{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
+          pattern: "**/[sS][uU][bB][11]{.CBL,.COB,.COBOL,.cbl,.cob,.cobol}",
         },
         null,
         1,

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -98,12 +98,27 @@ async function initialize(context: vscode.ExtensionContext) {
   }
   const maybeE4E = await getE4EAPI();
   const maybeZowe = await Utils.getZoweExplorerAPI();
+
+  languageClientService = new LanguageClientService(
+    outputChannel,
+    context.globalStorageUri,
+    {
+      executeCommand: (command, args, next) => {
+        if (command == "missing copybook") {
+          copyBooksDownloader.clearProfiles();
+        }
+        next(command, args);
+      },
+    },
+  );
+
   const copyBooksDownloader = new CopybookDownloadService(
     context.globalStorageUri,
     maybeZowe && "api" in maybeZowe ? maybeZowe.api : undefined,
     maybeE4E && "api" in maybeE4E ? maybeE4E.api : undefined,
     outputChannel,
     new DownloadDiagnosticsService(),
+    () => languageClientService.invalidateConfiguration(),
   );
 
   if (maybeZowe && "futureApi" in maybeZowe) {
@@ -119,18 +134,6 @@ async function initialize(context: vscode.ExtensionContext) {
       else outputChannel.appendLine(E4E_INCOMPATIBLE);
     });
 
-  languageClientService = new LanguageClientService(
-    outputChannel,
-    context.globalStorageUri,
-    {
-      executeCommand: (command, args, next) => {
-        if (command == "missing copybook") {
-          copyBooksDownloader.clearProfiles();
-        }
-        next(command, args);
-      },
-    },
-  );
   const configurationWatcher = new ConfigurationWatcher();
 
   return {

--- a/clients/cobol-lsp-vscode-extension/src/services/LocalFilesystemResourceService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LocalFilesystemResourceService.ts
@@ -91,14 +91,19 @@ export class LocalFilesystemResourceService {
       return `.${extension}`;
     });
 
+    const caseInsensitiveFilename = fileName
+      .split("")
+      .map((letter) => `[${letter.toLowerCase()}${letter.toUpperCase()}]`)
+      .join("");
+
     const fileNamePattern =
       sanitizedExtensions.length > 0
         ? "{" +
           sanitizedExtensions
-            .map((extension) => `${fileName}${extension}`)
+            .map((extension) => `${caseInsensitiveFilename}${extension}`)
             .join(",") +
           "}"
-        : fileName;
+        : caseInsensitiveFilename;
     const searchPattern = createFileSearchPattern(localPath, fileNamePattern);
     const files = await vscode.workspace.findFiles(searchPattern);
     return files[0];

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -449,7 +449,6 @@ export class CopybookDownloadService {
       !(await DownloadUtil.isProfileLocked(profile)) &&
       !(await DownloadUtil.checkForInvalidCredProfile(
         profile,
-        this.explorerApi,
         copybooksLocation,
       ))
     );

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -207,13 +207,13 @@ export class CopybookDownloadService {
       }),
       ...ussPaths.map(async (uss) => {
         const ussFiles = await this.ussDownloader?.getAllMembers(profile, uss);
-        return ussFiles?.map((f) => f.name) ?? [];
+        return ussFiles ?? [];
       }),
     ]);
 
     results.forEach((result) => {
       if (result.status === "fulfilled") {
-        result.value.forEach((c) => copybooks.push(c));
+        result.value.forEach((c) => copybooks.push(c.name));
       } else {
         this.outputChannel?.appendLine(
           `Unable to load copybooks completions. ${result.reason}`,

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -162,12 +162,14 @@ export class CopybookDownloadService {
     this.ussDownloader = new CopybookDownloaderForUss(this.explorerApi);
     this.dsnDownloader = new CopybookDownloaderForDsn(this.explorerApi);
     this.diagnosticsService?.clearDiagnostics();
-    this.explorerApi.onProfileUpdated((profile: IProfileLoaded) => {
-      this.outputChannel?.appendLine(`Zowe profile ${profile.name} updated`);
-      if (this.configurationInvalidation) {
-        this.configurationInvalidation();
-      }
-    });
+    if (this.explorerApi.onProfileUpdated) {
+      this.explorerApi.onProfileUpdated((profile: IProfileLoaded) => {
+        this.outputChannel?.appendLine(`Zowe profile ${profile.name} updated`);
+        if (this.configurationInvalidation) {
+          this.configurationInvalidation();
+        }
+      });
+    }
   }
 
   public async listRemoteCopybooks(

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -141,6 +141,7 @@ export class CopybookDownloadService {
     e4e?: E4E,
     private outputChannel?: vscode.OutputChannel,
     private diagnosticsService?: DownloadDiagnosticsService,
+    private configurationInvalidation?: () => unknown,
   ) {
     if (e4e) this.e4eAppeared(e4e);
     if (explorer) this.explorerAppeared(explorer);
@@ -161,6 +162,12 @@ export class CopybookDownloadService {
     this.ussDownloader = new CopybookDownloaderForUss(this.explorerApi);
     this.dsnDownloader = new CopybookDownloaderForDsn(this.explorerApi);
     this.diagnosticsService?.clearDiagnostics();
+    this.explorerApi.onProfileUpdated((profile: IProfileLoaded) => {
+      this.outputChannel?.appendLine(`Zowe profile ${profile.name} updated`);
+      if (this.configurationInvalidation) {
+        this.configurationInvalidation();
+      }
+    });
   }
 
   public async listRemoteCopybooks(

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/CopybookDownloadService.ts
@@ -552,7 +552,6 @@ export class CopybookDownloadService {
         if (
           await DownloadUtil.checkForInvalidCredProfile(
             tempProfile,
-            this.explorerApi,
             DATASET in zoweConfig
               ? { dsn: zoweConfig.dataset }
               : { uss: zoweConfig.uss },

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForDsn.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForDsn.ts
@@ -11,7 +11,7 @@
  * Contributors:
  *   Broadcom, Inc. - initial API and implementation
  */
-import { DownloadUtil } from "./DownloadUtil";
+import { splitFilename } from "../../util/FSUtils";
 import {
   MemberCacheItem,
   ZoweExplorerDownloader,
@@ -22,6 +22,9 @@ import * as vscode from "vscode";
  * Copybook downloader from MVS using Zowe Explorer
  */
 export class CopybookDownloaderForDsn extends ZoweExplorerDownloader {
+  protected schema = "zowe-ds";
+  protected separator = "/";
+
   constructor(explorerAPI: IApiRegisterClient) {
     super(explorerAPI);
   }
@@ -29,53 +32,32 @@ export class CopybookDownloaderForDsn extends ZoweExplorerDownloader {
   public async getAllMembers(
     profileName: string,
     dataset: string,
-  ): Promise<string[]> {
+  ): Promise<MemberCacheItem[]> {
     const id = this.createId(profileName, dataset);
 
     if (this.memberListCache.has(id)) {
-      return this.memberListCache.get(id)!.map((m) => m.name);
+      return this.memberListCache.get(id)!;
     }
-
-    const profile = DownloadUtil.loadProfile(profileName, this.explorerAPI);
 
     let members: MemberCacheItem[] = [];
     await this.limitFailedRequests(
       `list dataset members ${profileName}/${dataset}`,
       async () => {
-        const response = await this.explorerAPI
-          .getMvsApi(profile)
-          .allMembers(dataset);
-        members = response.apiResponse.items.map((item) => ({
-          name: item.member,
-        }));
+        const response = await vscode.workspace.fs.readDirectory(
+          vscode.Uri.parse(`${this.schema}:/${profileName}/${dataset}`),
+        );
+        members = response.map((item) => {
+          const [name, extension] = splitFilename(item[0]);
+          return {
+            name,
+            extension,
+          };
+        });
 
         this.memberListCache.set(id, members);
       },
     );
 
-    return members.map((m) => m.name);
-  }
-
-  public async hasMember(
-    profileName: string,
-    dataset: string,
-    copybookName: string,
-  ): Promise<boolean> {
-    const members = await this.getAllMembers(profileName, dataset);
-
-    copybookName = copybookName.toUpperCase();
-    return members.some((member) => member.toUpperCase() === copybookName);
-  }
-
-  public async resolveCopybookUri(
-    profileName: string,
-    dataset: string,
-    copybookName: string,
-  ) {
-    if (await this.hasMember(profileName, dataset, copybookName)) {
-      return vscode.Uri.parse(
-        `zowe-ds:/${profileName}/${dataset}/${copybookName}`,
-      );
-    }
+    return members;
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForUss.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/CopybookDownloaderForUss.ts
@@ -13,7 +13,6 @@
  */
 import { SettingsService } from "../../Settings";
 import { splitFilename } from "../../util/FSUtils";
-import { DownloadUtil } from "./DownloadUtil";
 import {
   MemberCacheItem,
   ZoweExplorerDownloader,
@@ -24,6 +23,9 @@ import * as vscode from "vscode";
  * Copybook downloader from USS using Zowe Explorer
  */
 export class CopybookDownloaderForUss extends ZoweExplorerDownloader {
+  protected schema = "zowe-uss";
+  protected separator = "";
+
   constructor(explorerAPI: IApiRegisterClient) {
     super(explorerAPI);
   }
@@ -38,8 +40,6 @@ export class CopybookDownloaderForUss extends ZoweExplorerDownloader {
       return this.memberListCache.get(id)!;
     }
 
-    const profile = DownloadUtil.loadProfile(profileName, this.explorerAPI);
-
     let allowedCopybooksExtensions =
       await SettingsService.getCopybookExtension();
     allowedCopybooksExtensions = allowedCopybooksExtensions?.map((ext) =>
@@ -52,13 +52,13 @@ export class CopybookDownloaderForUss extends ZoweExplorerDownloader {
     await this.limitFailedRequests(
       `list USS directory ${profileName}/${dataset}`,
       async () => {
-        const response = await this.explorerAPI
-          .getUssApi(profile)
-          .fileList(dataset);
+        const response = await vscode.workspace.fs.readDirectory(
+          vscode.Uri.parse(`${this.schema}:/${profileName}${dataset}`),
+        );
 
-        for (const file of response.apiResponse.items) {
-          if (file.mode.charAt(0) === "-") {
-            const [name, extension] = splitFilename(file.name);
+        for (const file of response) {
+          if (file[1] === vscode.FileType.File) {
+            const [name, extension] = splitFilename(file[0]);
 
             if (extension) {
               if (
@@ -76,33 +76,5 @@ export class CopybookDownloaderForUss extends ZoweExplorerDownloader {
 
     this.memberListCache.set(id, members);
     return members;
-  }
-
-  public async hasMember(
-    profileName: string,
-    uss: string,
-    copybookName: string,
-  ): Promise<boolean> {
-    const members = await this.getAllMembers(profileName, uss);
-    copybookName = copybookName.toUpperCase();
-    return members.some((member) => member.name.toUpperCase() === copybookName);
-  }
-
-  public async resolveCopybookUri(
-    profileName: string,
-    uss: string,
-    copybookName: string,
-  ) {
-    const memberList = await this.getAllMembers(profileName, uss);
-    copybookName = copybookName.toUpperCase();
-    const member = memberList.find(
-      (m) => m.name.toUpperCase() === copybookName,
-    );
-
-    if (member) {
-      return vscode.Uri.parse(
-        `zowe-uss:/${profileName}${uss}/${member.name}${member.extension}`,
-      );
-    }
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -75,6 +75,7 @@ export class DownloadUtil {
     profileName: string,
     explorerAPI: IApiRegisterClient,
     remoteLocation: MainframeRemoteLocation,
+    retry = true,
   ): Promise<boolean> {
     if (
       ZoweExplorerDownloader.profileStore.get(profileName) === "valid-profile"
@@ -83,13 +84,30 @@ export class DownloadUtil {
     }
 
     try {
-      const profile = this.loadProfile(profileName, explorerAPI);
       if (remoteLocation.uss) {
-        await explorerAPI.getUssApi(profile).fileList(remoteLocation.uss);
+        await vscode.workspace.fs.stat(
+          vscode.Uri.parse(
+            `zowe-uss:/${profileName}/${remoteLocation.uss}?fetch=true`,
+          ),
+        );
       } else if (remoteLocation.dsn) {
-        await explorerAPI.getMvsApi(profile).allMembers(remoteLocation.dsn);
+        await vscode.workspace.fs.stat(
+          vscode.Uri.parse(
+            `zowe-ds:/${profileName}/${remoteLocation.dsn}?fetch=true`,
+          ),
+        );
       }
     } catch (error) {
+      // TODO: This retry mechanism should be removed once this ZE bug is fixed
+      // https://github.com/zowe/zowe-explorer-vscode/issues/3662
+      if (retry) {
+        return await this.checkForInvalidCredProfile(
+          profileName,
+          explorerAPI,
+          remoteLocation,
+          false,
+        );
+      }
       if (this.checkForInvalidCredentials(error, profileName)) {
         return true;
       }
@@ -126,11 +144,6 @@ export class DownloadUtil {
 
     if (this.isInvalidCredentials(e)) {
       ZoweExplorerDownloader.profileStore.set(profileName, "locked-profile");
-      const errorMessage = INVALID_CREDENTIALS_ERROR_MSG.replace(
-        PROFILE_NAME_PLACEHOLDER,
-        profileName,
-      );
-      vscode.window.showErrorMessage(errorMessage);
       return true;
     }
 
@@ -212,9 +225,11 @@ export class DownloadUtil {
    */
   private static isInvalidCredentials(e: unknown) {
     return (
-      hasMember(e, "mDetails") &&
-      hasMember(e.mDetails, "errorCode") &&
-      e.mDetails.errorCode === 401
+      hasMember(e, "message") &&
+      typeof e.message === "string" &&
+      e.message.includes(
+        "Rest API failure with HTTP(S) status 401\nThis operation requires authentication.",
+      )
     );
   }
 
@@ -225,9 +240,6 @@ export class DownloadUtil {
    */
   private static isPermissionError(e: unknown) {
     return (
-      hasMember(e, "mDetails") &&
-      hasMember(e.mDetails, "errorCode") &&
-      e.mDetails.errorCode === 500 &&
       hasMember(e, "message") &&
       typeof e.message === "string" &&
       (e.message.includes("EDC5111I Permission denied") ||
@@ -240,11 +252,7 @@ export class DownloadUtil {
    * selected dataset or uss folder doesn't exist.
    */
   private static isNotFoundError(e: unknown) {
-    return (
-      hasMember(e, "mDetails") &&
-      hasMember(e.mDetails, "errorCode") &&
-      e.mDetails.errorCode === 404
-    );
+    return hasMember(e, "code") && e.code === "FileNotFound";
   }
   public static endevorConfigToType(config: EndevorConfigModel): EndevorType {
     return {

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/DownloadUtil.ts
@@ -14,7 +14,6 @@
 import * as vscode from "vscode";
 import {
   DOWNLOAD_QUEUE_LOCKED_ERROR_MSG,
-  INVALID_CREDENTIALS_ERROR_MSG,
   PROFILE_NAME_PLACEHOLDER,
   UNLOCK_DOWNLOAD_QUEUE_MSG,
 } from "../../../constants";
@@ -29,51 +28,14 @@ import { EndevorConfigModel } from "../../ProcessorGroupsLoader";
  * Utility class for downloading copybooks
  */
 export class DownloadUtil {
-  public static getRemoteCopybookName(members: string[], copybookName: string) {
-    const copybookNameUpperCase = copybookName.toUpperCase();
-    return members.find(
-      (ele) =>
-        DownloadUtil.getFilenameWithoutExtension(ele).toUpperCase() ===
-        copybookNameUpperCase,
-    );
-  }
-
-  /**
-   * Retrieves a filename excluding extension for a passed file name
-   * @param ele filename
-   * @returns filename excluding extension
-   */
-  public static getFilenameWithoutExtension(ele: string) {
-    return ele.substring(
-      0,
-      ele.lastIndexOf(".") !== -1 ? ele.lastIndexOf(".") : ele.length,
-    );
-  }
-
-  /**
-   * Checks if path exists
-   * @param path path
-   * @returns boolean
-   */
-  public static async checkPathExists(path: string): Promise<boolean> {
-    try {
-      await vscode.workspace.fs.stat(vscode.Uri.file(path));
-      return true; // Path exists
-    } catch (_error) {
-      return false;
-    }
-  }
-
   /**
    * returns true if the passed profile has invalid credentials, false otherwise
    * @param profileName
-   * @param explorerAPI
    * @param remoteLocation DSN or USS that is used to test mainframe access
    * @returns true if the passed profile has invalid credentials, false otherwise
    */
   public static async checkForInvalidCredProfile(
     profileName: string,
-    explorerAPI: IApiRegisterClient,
     remoteLocation: MainframeRemoteLocation,
     retry = true,
   ): Promise<boolean> {
@@ -103,7 +65,6 @@ export class DownloadUtil {
       if (retry) {
         return await this.checkForInvalidCredProfile(
           profileName,
-          explorerAPI,
           remoteLocation,
           false,
         );
@@ -115,22 +76,6 @@ export class DownloadUtil {
 
     ZoweExplorerDownloader.profileStore.set(profileName, "valid-profile");
     return false;
-  }
-
-  /**
-   * returns IProfileLoaded from a passed profile name
-   * @param profileName
-   * @param explorerAPI
-   * @returns IProfileLoaded
-   */
-  public static loadProfile(
-    profileName: string,
-    explorerAPI: IApiRegisterClient,
-  ): IProfileLoaded {
-    return explorerAPI
-      .getExplorerExtenderApi()
-      .getProfilesCache()
-      .loadNamedProfile(profileName);
   }
 
   private static checkForInvalidCredentials(

--- a/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/ZoweExplorerDownloader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/copybook/downloader/ZoweExplorerDownloader.ts
@@ -25,6 +25,8 @@ export abstract class ZoweExplorerDownloader {
     new Map();
   protected memberListCache: Map<string, MemberCacheItem[]> = new Map();
   protected failedRequests: Map<string, number> = new Map();
+  protected abstract schema: string;
+  protected abstract separator: string;
 
   constructor(protected readonly explorerAPI: IApiRegisterClient) {}
 
@@ -72,6 +74,35 @@ export abstract class ZoweExplorerDownloader {
 
         throw err;
       }
+    }
+  }
+
+  public async hasMember(
+    profileName: string,
+    uss: string,
+    copybookName: string,
+  ): Promise<MemberCacheItem | undefined> {
+    const members = await this.getAllMembers(profileName, uss);
+    copybookName = copybookName.toUpperCase();
+    return members.find((member) => member.name.toUpperCase() === copybookName);
+  }
+
+  public abstract getAllMembers(
+    profileName: string,
+    dataset: string,
+  ): Promise<MemberCacheItem[]>;
+
+  public async resolveCopybookUri(
+    profileName: string,
+    dataset: string,
+    copybookName: string,
+  ) {
+    const member = await this.hasMember(profileName, dataset, copybookName);
+
+    if (member) {
+      return vscode.Uri.parse(
+        `${this.schema}:/${profileName}${this.separator}${dataset}/${member.name}${member.extension ? member.extension : ""}`,
+      );
     }
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -84,7 +84,7 @@ export function getVariablesFromUri(
   };
 }
 
-export function splitFilename(filename: string): [string, string | null] {
+export function splitFilename(filename: string): [string, string] | [string] {
   const lastDotIndex = filename.lastIndexOf(".");
   if (lastDotIndex > 0) {
     const name = filename.slice(0, lastDotIndex);
@@ -92,6 +92,6 @@ export function splitFilename(filename: string): [string, string | null] {
 
     return [name, extension];
   } else {
-    return [filename, null];
+    return [filename];
   }
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/SubroutineUtils.ts
@@ -24,16 +24,21 @@ import * as vscode from "vscode";
 export async function resolveSubroutineURI(name: string) {
   const subroutinePaths = SettingsService.getSubroutineLocalPath();
 
+  const caseInsensitiveName = name
+    .split("")
+    .map((letter) => `[${letter.toLowerCase()}${letter.toUpperCase()}]`)
+    .join("");
+
   if (subroutinePaths) {
     for (const subroutinePath of subroutinePaths) {
       let pattern: vscode.RelativePattern | string;
       if (isAbsolute(subroutinePath)) {
         pattern = new vscode.RelativePattern(
           subroutinePath,
-          `**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`,
+          `**/${caseInsensitiveName}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`,
         );
       } else {
-        pattern = `${subroutinePath}/**/${name}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
+        pattern = `${subroutinePath}/**/${caseInsensitiveName}{${COBOL_EXT_ARRAY_CASE_INSENSITIVE.join(",")}}`;
       }
 
       const uris = await vscode.workspace.findFiles(pattern, null, 1);

--- a/clients/cobol-lsp-vscode-extension/src/type/zoweApi.d.ts
+++ b/clients/cobol-lsp-vscode-extension/src/type/zoweApi.d.ts
@@ -20,6 +20,7 @@ interface IApiRegisterClient {
   getUssApi(profile: IProfileLoaded): IUss;
   getMvsApi(profile: IProfileLoaded): IMvs;
   registeredApiTypes(): string[];
+  onProfileUpdated(fn: (profile: IProfileLoaded) => unknown): void;
 }
 
 interface IApiExplorerExtender {


### PR DESCRIPTION
 - Send `workspace/didChangeConfiguration` notification to the server when user logs into Zowe explorer and Zowe resources become available.
 - Include `.cpy` extension in the Uri - so changes made in copybooks opened through ZE are reflected in programs
 - Use FSProvider for everything - Zowe API should not be used anywhere in the code
 - Make local copybooks and subroutines search case insensitive

## How Has This Been Tested?

Manual testing

## Checklist:
- [ ] Each of my commits contains one meaningful change
- [ ] I have performed rebase of my branch on top of the development
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
